### PR TITLE
Updated readme with version req

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ A simple CLI to download full Frontend Masters courses to watch off-line.
 npm install fm-download -g
 ````
 
+## Requirements
+
+* Node v8.3 or higher
+
 ## Usage
 
 ```


### PR DESCRIPTION
Spread operator on objects will fire an error prior to node 8.3. Though I guess the harmony flag could suffice as a workaround.